### PR TITLE
Fix URL to "How to resolve" section of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Not directly called at all:
 lib/hello_world.rb:6:6 generated_method= attr_accessor :generated_method
 lib/hello_world.rb:6:6 generated_method attr_accessor :generated_method
 
-how to resolve: https://github.com/robotdana/leftovers/tree/main/Readme.md#how_to_resolve
+how to resolve: https://github.com/robotdana/leftovers/tree/main/Readme.md#how-to-resolve
 ```
 
 if there is an overwhelming number of results, try using [`--write-todo`](#write-todo)

--- a/lib/leftovers.rb
+++ b/lib/leftovers.rb
@@ -93,7 +93,7 @@ module Leftovers # rubocop:disable Metrics/ModuleLength
     end
 
     def resolution_instructions_link
-      "https://github.com/robotdana/leftovers/tree/v#{Leftovers::VERSION}/README.md#how_to_resolve"
+      "https://github.com/robotdana/leftovers/tree/v#{Leftovers::VERSION}/README.md#how-to-resolve"
     end
 
     def warn(message)

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Leftovers::CLI, type: :cli do
           # Generated at: 2021-06-14 22:03:35 UTC
           #
           # for instructions on how to address these
-          # see https://github.com/robotdana/leftovers/tree/v#{Leftovers::VERSION}/README.md#how_to_resolve
+          # see https://github.com/robotdana/leftovers/tree/v#{Leftovers::VERSION}/README.md#how-to-resolve
 
           test_only:
             # Defined in tests:
@@ -153,7 +153,7 @@ RSpec.describe Leftovers::CLI, type: :cli do
           # Generated at: 2021-06-14 22:03:35 UTC
           #
           # for instructions on how to address these
-          # see https://github.com/robotdana/leftovers/tree/v#{Leftovers::VERSION}/README.md#how_to_resolve
+          # see https://github.com/robotdana/leftovers/tree/v#{Leftovers::VERSION}/README.md#how-to-resolve
 
           keep:
             # Not directly called at all:
@@ -213,7 +213,7 @@ RSpec.describe Leftovers::CLI, type: :cli do
           # Generated at: 2021-06-14 22:03:35 UTC
           #
           # for instructions on how to address these
-          # see https://github.com/robotdana/leftovers/tree/v#{Leftovers::VERSION}/README.md#how_to_resolve
+          # see https://github.com/robotdana/leftovers/tree/v#{Leftovers::VERSION}/README.md#how-to-resolve
 
           keep:
             # Not directly called at all:
@@ -248,7 +248,7 @@ RSpec.describe Leftovers::CLI, type: :cli do
           # Generated at: 2021-06-14 22:03:35 UTC
           #
           # for instructions on how to address these
-          # see https://github.com/robotdana/leftovers/tree/v#{Leftovers::VERSION}/README.md#how_to_resolve
+          # see https://github.com/robotdana/leftovers/tree/v#{Leftovers::VERSION}/README.md#how-to-resolve
 
           keep:
             # Not directly called at all:
@@ -391,7 +391,7 @@ RSpec.describe Leftovers::CLI, type: :cli do
             # Generated at: 2021-06-14 22:03:35 UTC
             #
             # for instructions on how to address these
-            # see https://github.com/robotdana/leftovers/tree/v#{Leftovers::VERSION}/README.md#how_to_resolve
+            # see https://github.com/robotdana/leftovers/tree/v#{Leftovers::VERSION}/README.md#how-to-resolve
 
             test_only:
               # Defined in tests:
@@ -438,7 +438,7 @@ RSpec.describe Leftovers::CLI, type: :cli do
             # Generated at: 2021-06-14 22:03:35 UTC
             #
             # for instructions on how to address these
-            # see https://github.com/robotdana/leftovers/tree/v#{Leftovers::VERSION}/README.md#how_to_resolve
+            # see https://github.com/robotdana/leftovers/tree/v#{Leftovers::VERSION}/README.md#how-to-resolve
 
             test_only:
               # Defined in tests:


### PR DESCRIPTION
When GitHub auto-generates IDs on headings in Markdown files, the slug it creates is word-separated by hyphens, not underscores. This PR changes the anchor in the URL that's displayed in the output when there is unused code found.

# Before

```
how to resolve: https://github.com/robotdana/leftovers/tree/v0.5.2/README.md#how_to_resolve
```

# After

```
how to resolve: https://github.com/robotdana/leftovers/tree/v0.5.2/README.md#how-to-resolve
```

***

Commits;

- Change underscores to hyphens in URL to README