### PR TITLE
Fix crash when encountering constant reassignment

### DIFF
--- a/lib/leftovers/file_collector.rb
+++ b/lib/leftovers/file_collector.rb
@@ -97,7 +97,7 @@ module Leftovers
       when :send, :csend then calls << :"#{node.name}="
       # just collects the call, super will collect the definition
       when :ivasgn, :gvasgn, :cvasgn then calls << node.name
-      when :lvasgn then nil # we don't care about lvasgn
+      when :lvasgn, :casgn then nil # we don't care about lvasgn or casgn
       # :nocov:
       else raise Leftovers::UnexpectedCase, "Unhandled value #{node.type.inspect}"
         # :nocov:

--- a/spec/file_collector/literal_spec.rb
+++ b/spec/file_collector/literal_spec.rb
@@ -269,6 +269,15 @@ RSpec.describe Leftovers::FileCollector do
     end
   end
 
+  context 'with constant reassignment' do
+    let(:ruby) { 'Whatever ||= Class.new' }
+
+    it do
+      expect(subject).to have_definitions(:Whatever)
+        .and(have_calls(:Class, :new, :allocate, :initialize))
+    end
+  end
+
   context 'with method calls in hash values' do
     let(:ruby) { '{ call: this }' }
 


### PR DESCRIPTION
I ran into an issue where, if you run `leftovers` against a codebase that was memoizing a constant, it would crash with gusto:

![image](https://user-images.githubusercontent.com/3387824/182482246-936df299-a584-4f3a-8047-4a6b11c5125f.png)

Memoizing constants is its own thing to deal with (and more of the domain of a linter than this tool), though it didn't seem like something that should prevent `leftovers` from completing a run. 

I added the [`:casgn` node type](https://lib-ruby-parser.github.io/ruby-bindings/LibRubyParser/Nodes/Casgn.html) to the `FileCollector` to ignore it in the same way it ignores local variable assignments, and added a corresponding spec.

If there are any other specs you'd like to update, let me know.