### PR TITLE
Safe navigate the first node's `sym?` method

### DIFF
--- a/lib/leftovers/file_collector/node_processor.rb
+++ b/lib/leftovers/file_collector/node_processor.rb
@@ -100,7 +100,7 @@ module Leftovers
       # grab e.g. :to_s in each(&:to_s)
       def on_block_pass(node)
         super
-        return unless node.first.sym?
+        return unless node.first&.sym?
 
         @collector.calls << node.first.to_sym
       end


### PR DESCRIPTION
fixes #21 

This line was causing a nil reference in a build pipeline.